### PR TITLE
Make mountarchive work with Firefox

### DIFF
--- a/settings/packages.hello
+++ b/settings/packages.hello
@@ -1,6 +1,6 @@
 # Graphical login manager for X11
 slim
-# Required for hello QtPlugin and Menu
+# Required for helloSystem QtPlugin and Menu
 kf5-kdbusaddons
 libdbusmenu-qt5
 # Required for gmenudbusmenuproxy
@@ -127,6 +127,8 @@ font-awesome
 libappindicator
 # Needed for mountarchive tool to mount archives and disk images
 archivemount
+# To handle .zip archives more reliably than mountarchive
+deskutils/lumina-archiver
 # Needed to load HiDPI cursors [ci skip]
 xrdb
 # Needed for Simple Browser


### PR DESCRIPTION
Include [deskutils/lumina-archiver](https://www.freshports.org/deskutils/lumina-archiver/) 

* Archive Manager
* also known as Lumina Archiver.

### Rationale

With helloSystem initially limited to `local/mountarchive` a.k.a. Mount Archive alone, `.zip` files such as this are not handled properly: 

![unzip failed](https://user-images.githubusercontent.com/192271/106876740-f59e7c80-66cf-11eb-9f52-d2b6913ebdc3.png)

Context: 

https://dev.languagetool.org/http-server

![Mount Archive alone](https://user-images.githubusercontent.com/192271/106876827-0d760080-66d0-11eb-8d35-d8c60e06674a.png)

* Mount Archive alone

![nothing else available](https://user-images.githubusercontent.com/192271/106876864-1666d200-66d0-11eb-9e7c-998b2441a454.png)

* nothing else available. 

```text
FreeBSD% pkg query '%o %v %R' hello firefox mountarchive
helloSystem 0.4.0_0D26 unknown-repository
www/firefox 81.0.1,2 FreeBSD
local 0 unknown-repository
FreeBSD% pkg info mountarchive
mountarchive-0
Name           : mountarchive
Version        : 0
Installed on   : Sun Jan 31 10:09:34 2021 EST
Origin         : local
Architecture   : FreeBSD:12:amd64
Prefix         : /
Categories     : local
Licenses       : BSD
Maintainer     : n/a
WWW            : n/a
Comment        : Package that installs FuryBSD configuration
Annotations    :
        FreeBSD_version: 1201000
Flat size      : 5.75KiB
Description    :
Package that installs FuryBSD configuration
FreeBSD% freebsd-version -kru                           
12.1-RELEASE
12.1-RELEASE
12.1-RELEASE
FreeBSD% uname -v
FreeBSD 12.1-RELEASE r354233 GENERIC 
FreeBSD% uptime
 4:28AM  up  2:28, 0 users, load averages: 0.07, 0.07, 0.08
FreeBSD% 
% 
```

### With `deskutils/lumina-archiver`

![Archive Manager](https://user-images.githubusercontent.com/192271/106877000-38605480-66d0-11eb-9ee1-e9987358f64b.png)

![also known as Lumina Archiver](https://user-images.githubusercontent.com/192271/106877062-44e4ad00-66d0-11eb-94d1-60ef670e6b98.png)
