### PR TITLE
Fixes to unionfs boot

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -260,10 +260,7 @@ ramdisk()
 boot() 
 {
   cp -R "${cwd}/overlays/boot/" "${cdroot}"
-  cd "${uzip}" && tar -cf - --exclude boot/kernel boot | tar -xf - -C "${cdroot}"
-  for kfile in kernel geom_uzip.ko opensolaris.ko tmpfs.ko xz.ko zfs.ko; do
-  tar -cf - boot/kernel/${kfile} | tar -xf - -C "${cdroot}"
-  done
+  cd "${uzip}" && tar -cf - boot | tar -xf - -C "${cdroot}"
   cd ${cwd} && zpool export furybsd && mdconfig -d -u 0
 }
 

--- a/build.sh
+++ b/build.sh
@@ -145,7 +145,8 @@ packages()
   # as long as the previous dot release is still supported; FIXME
   # https://forums.freebsd.org/threads/i915kms-package-breaks-on-12-2-release-workaround-build-from-ports.77501/
   # FIXME: Add https://darkness-pi.monwarez.ovh/posts/synth-repository/ properly. How?
-  IGNORE_OSVERSION=yes /usr/local/sbin/pkg-static -c "${uzip}" add https://darkness-pi.monwarez.ovh/amd64/All/drm-fbsd12.0-kmod-4.16.g20200221.txz
+  # 02-22-2021 Disabled pkg add command which has broken URL and won't fetch
+  # IGNORE_OSVERSION=yes /usr/local/sbin/pkg-static -c "${uzip}" add https://darkness-pi.monwarez.ovh/amd64/All/drm-fbsd12.0-kmod-4.16.g20200221.txz
   /usr/local/sbin/pkg-static -c ${uzip} info > "${cdroot}/data/system.uzip.manifest"
   cp "${cdroot}/data/system.uzip.manifest" "${isopath}.manifest"
   rm ${uzip}/etc/resolv.conf

--- a/build.sh
+++ b/build.sh
@@ -241,8 +241,10 @@ script()
 uzip() 
 {
   install -o root -g wheel -m 755 -d "${cdroot}"
+  makefs "${cdroot}/data/system.ufs" "${uzip}"
+  mkuzip -o "${cdroot}/data/system.uzip" "${cdroot}/data/system.ufs"
+  rm -f "${cdroot}/data/system.ufs"
   cd ${cwd} && zpool export furybsd && while zpool status furybsd >/dev/null; do :; done 2>/dev/null
-  mkuzip -S -d -o "${cdroot}/data/system.uzip" "${livecd}/pool.img"
 }
 
 ramdisk() 

--- a/overlays/boot/boot/loader.conf
+++ b/overlays/boot/boot/loader.conf
@@ -24,7 +24,7 @@ vfs.root.mountfrom="ufs:/dev/md0"
 init_path="/rescue/init"
 init_shell="/rescue/sh"
 init_script="/init.sh"
-init_chroot="/"
+init_chroot="/sysroot"
 
 kern.geom.label.disk_ident.enable=0
 kern.geom.label.gptid.enable=0

--- a/overlays/ramdisk/etc/rc
+++ b/overlays/ramdisk/etc/rc
@@ -1,5 +1,0 @@
-#!/rescue/sh
-
-umount -f /cdrom
-cp /memdisk/init-reroot.sh /
-reboot -r

--- a/overlays/ramdisk/init.sh
+++ b/overlays/ramdisk/init.sh
@@ -41,7 +41,6 @@ fi
 
 echo "==> Mount unionfs"
 mdmfs -s "${MEMDISK_SIZE}m" md /memdisk || exit 1
-kldload unionfs
 mount -t unionfs /memdisk /sysroot
 
 echo "==> Change into /sysroot"

--- a/overlays/uzip/furybsd-settings/files/etc/fstab
+++ b/overlays/uzip/furybsd-settings/files/etc/fstab
@@ -1,1 +1,0 @@
-/dev/md2	/	ufs	rw	0	0

--- a/settings/packages.common
+++ b/settings/packages.common
@@ -14,7 +14,6 @@ xf86-video-vesa
 xf86-video-vmware
 xf86-video-qxl # !i386
 drm-kmod
-drm-legacy-kmod
 libva-intel-driver
 drm-kmod
 nvidia-driver # !i386

--- a/settings/rc.conf.common
+++ b/settings/rc.conf.common
@@ -1,1 +1,6 @@
 hostname="furybsd"
+root_rw_mount="NO"
+sendmail_enable="NONE"
+sendmail_submit_enable="NO"
+sendmail_outbound_enable="NO"
+sendmail_msp_queue_enable="NO"


### PR DESCRIPTION
Installer will still need work to use cpdup or rsync since we are using union instead of ZFS stream + replication in this branch.  It looks like a lot of hello customizations are also missing from this branch?  Hopefully this at least gives you the missing pieces to unblock you from trying using unionfs with proper branch.