### PR TITLE
Add ability to add custom packages

### DIFF
--- a/settings/packages.common-12
+++ b/settings/packages.common-12
@@ -10,14 +10,12 @@ xf86-input-mouse
 xf86-input-vmmouse
 xf86-video-ati
 xf86-video-cirrus
+xf86-video-intel
 xf86-video-scfb
 xf86-video-vesa
 xf86-video-vmware
 xf86-video-qxl # !i386
-drm-kmod
-drm-legacy-kmod
 libva-intel-driver
-drm-kmod
 # nvidia-driver # !i386 # Is now handled in build.sh initgfx()
 mesa-libs
 mesa-dri
@@ -60,3 +58,6 @@ b43-fwcutter
 dsbdriverd
 # Control screen brightness on some Intel-based machines including MacBook Pro
 intel-backlight
+https://www.bayofrum.net/~crees/pkg/hello-12.2%%ARCH%%-drm/gpu-firmware-kmod-g20201213.txz
+https://www.bayofrum.net/~crees/pkg/hello-12.2%%ARCH%%-drm/drm-fbsd12.0-kmod-4.16.g20201016_1.txz
+https://www.bayofrum.net/~crees/pkg/hello-12.2%%ARCH%%-drm/drm-kmod-g20190710_1.txz

--- a/settings/packages.common-12
+++ b/settings/packages.common-12
@@ -19,6 +19,7 @@ libva-intel-driver
 # nvidia-driver # !i386 # Is now handled in build.sh initgfx()
 mesa-libs
 mesa-dri
+gpu-firmware-kmod
 open-vm-tools
 virtualbox-ose-additions
 xauth
@@ -58,6 +59,4 @@ b43-fwcutter
 dsbdriverd
 # Control screen brightness on some Intel-based machines including MacBook Pro
 intel-backlight
-https://www.bayofrum.net/~crees/pkg/hello-12.2%%ARCH%%-drm/gpu-firmware-kmod-g20201213.txz
-https://www.bayofrum.net/~crees/pkg/hello-12.2%%ARCH%%-drm/drm-fbsd12.0-kmod-4.16.g20201016_1.txz
-https://www.bayofrum.net/~crees/pkg/hello-12.2%%ARCH%%-drm/drm-kmod-g20190710_1.txz
+cirrus:github/crees/drm-kmod-FreeBSD-12/main/binaries/drm-fbsd12.0-kmod-%%VER%%%%ARCH%%.txz


### PR DESCRIPTION
Since drm-kmod is never going to match 12.2, we should just fix this now.

Any line starting with https in the package files is pulled separately.
They should be in reverse order of dependencies.

I've build drm-kmod for 12.2, but of course these could come from anywhere.

The logic for pulling pkgs from https is reusable and should work just fine with any location- I fully understand that you may not want it to pull from some untrusted and unknown site!