### PR TITLE
.cirrus.yml: remove ambiguity for script value

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -52,5 +52,5 @@ task:
     - case "$CIRRUS_BRANCH" in *pull/*) echo skipping since PR ;; * ) wget https://github.com/tcnksm/ghr/files/5247714/ghr.zip ; unzip ghr.zip ; ./ghr -prerelease -delete -t "${GITHUB_TOKEN}" -u "${CIRRUS_REPO_OWNER}" -r "${CIRRUS_REPO_NAME}" -c "${CIRRUS_CHANGE_IN_REPO}" "${CIRRUS_BRANCH}"-"${VER}" "${CIRRUS_WORKING_DIR}"/artifacts ; esac
 
   FreeNode_script:
-    echo "TODO: Fix IRC bot script"
+    - echo "TODO: Fix IRC bot script"
     # case "$CIRRUS_BRANCH" in *pull/*) echo skipping since PR ;; * ) echo -e 'USER helloSystemBot guest tolmoon tolsun\nNICK helloSystemBot\nJOIN #helloSystem\nPRIVMSG #helloSystem :A new build is now available in the Create Live Media tool, happy testing!\nQUIT\n' | nc irc.freenode.net 6667 >/dev/null ; esac


### PR DESCRIPTION
Hi!

We're going to make some changes to how Cirrus CI parses configurations in the next couple of weeks (there's no press-release ATM) and found some potential issues with your `.cirrus.yml` while doing backwards compatibility checks.

`FreeNode` script [currently defines a map](https://onlineyamltools.com/convert-yaml-to-json?input=%20%20FreeNode_script%3A%0A%20%20%20%20echo%20%22TODO%3A%20Fix%20IRC%20bot%20script%22&indent-use-spaces=true&indent-spaces=2&indent-use-tabs=false) instead of a scalar/sequence value, which works now only due to parser implementation peculiarities.

This change makes sure the transition goes smoothly.