### PR TITLE
Intel fix

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -194,6 +194,7 @@ packages()
         fetch -o ${uzip}${pkg_cachedir}/furybsd-cirrus/ $url
       fi
       /usr/local/sbin/pkg-static -c "${uzip}" add ${pkg_cachedir}/furybsd-cirrus/${pkgfile}
+      /usr/local/sbin/pkg-static -c "${uzip}" lock -y $(/usr/local/sbin/pkg-static query -F ${uzip}${pkg_cachedir}/furybsd-cirrus/${pkgfile} %o)
     done
   done
   # Install the packages we have generated in pkg() that are listed in transient-packages-list

--- a/overlays/uzip/initgfx/files/etc/rc.d/initgfx
+++ b/overlays/uzip/initgfx/files/etc/rc.d/initgfx
@@ -129,10 +129,8 @@ get_device_info() {
 		sed -E 's#.* chip=0x([0-9a-z]{4})([0-9a-z]{4}).*$#\1:\2#')
 	busID=$(pciconf -lv | grep ^vgapci${unit} | head -1 | \
 		sed -E 's/^vgapci[0-9]@pci[0-9]:([0-9:]+):.*$/\1/')
-	#vendor=$(echo "${chip}" | cut -d: -f2)
-	#device=$(echo "${chip}" | cut -d: -f1)
-	vendor=$(pciconf -lv | grep ^vgapci${unit} | head -n 1 | grep -oe ' vendor=0x....' | cut -d x -f 2)
-	device=$(pciconf -lv | grep ^vgapci${unit} | head -n 1 | grep -oe ' device=0x....' | cut -d x -f 2)
+	vendor=$(echo "${chip}" | cut -d: -f2)
+	device=$(echo "${chip}" | cut -d: -f1)
 }
 
 rc_conf_d_ldconfig()
@@ -188,7 +186,7 @@ setup_nvidia()
 
 	[ "${vendor}" != "10de" ] && return 1
 	device=$(pciconf -lv | grep -A3 ^vgapci${unit} | grep device | \
-		cut -d"'" -f 2 | tail -n 1)
+		cut -d"'" -f 2)
 	driver=""
 	for d in 440 390 340 304; do
 		nvidia_${d}_ids | awk -v device="$device" '

--- a/overlays/uzip/initgfx/files/etc/rc.d/initgfx
+++ b/overlays/uzip/initgfx/files/etc/rc.d/initgfx
@@ -50,6 +50,7 @@ path_initgfx_xorg_templates="/etc/${name}_xorg.cfg"
 path_initgfx_device_db="/etc/${name}_device.db"
 
 path_cfg_test_dir="/tmp/${name}.$$"
+path_tmp_rc_conf="/tmp/rc.conf.$$"
 
 # Include device info DB
 . ${path_initgfx_device_db}
@@ -113,24 +114,54 @@ set_kldconfig_path()
 
 test_x()
 {
+	local cmd
+
 	if [ ! -d "${path_cfg_test_dir}" ]; then
 		mkdir "${path_cfg_test_dir}" 2>/dev/null
 	fi
 	cp "${path_xorg_cfg}" "${path_cfg_test_dir}"
+	if [ -x /usr/local/bin/xmessage ]; then
+		cmd="/usr/local/bin/xmessage -buttons '' -timeout 3"
+		cmd="${cmd} -center 'Please wait ...'"
+	else
+		cmd="sleep 3"
+	fi
 	PATH="${PATH}:/usr/local/bin" /usr/local/bin/xinit \
-		/usr/bin/true -- -configdir "${path_cfg_test_dir}"
+		/bin/sh -c "${cmd}; /usr/bin/true" -- -configdir \
+			"${path_cfg_test_dir}"
 }
 
-get_device_info() {
-	local chip
+get_device_info()
+{
 	unit=$(sysctl -n hw.pci.default_vgapci_unit)
 	[ -z "$unit" -o "$unit" =  "-1" ] && unit=0
-	chip=$(pciconf -lv | grep ^vgapci${unit} | head -1 | \
-		sed -E 's#.* chip=0x([0-9a-z]{4})([0-9a-z]{4}).*$#\1:\2#')
-	busID=$(pciconf -lv | grep ^vgapci${unit} | head -1 | \
-		sed -E 's/^vgapci[0-9]@pci[0-9]:([0-9:]+):.*$/\1/')
-	vendor=$(echo "${chip}" | cut -d: -f2)
-	device=$(echo "${chip}" | cut -d: -f1)
+	local info=$(pciconf -lv | grep "^vgapci${unit}" | awk -F'[ \t]+' ' {
+		for (i = 1; i <= NF; i++) {
+			if ($i ~ /^vgapci[0-9]/) {
+				if (split($i, a, ":") < 4)
+					exit(1);
+				busID = sprintf("%d:%d:%d", a[2], a[3], a[4])
+			} else if ($i ~ /^chip=/) {
+				device = substr($i, 8, 4);
+				vendor = substr($i, 12, 4);
+			} else if ($i ~ /^vendor=/) {
+				split($i, a, /=0x/);
+				vendor = a[2];
+			} else if ($i ~ /^device=/) {
+				split($i, a, /=0x/);
+				device = a[2];
+			}
+		}
+	}
+	END {
+		printf("%s %s %s", busID, vendor, device);
+	}')
+	set -- $info
+	device=$3; vendor=$2; busID=$1
+	if [ -z "${vendor}" -o -z "${device}" -o -z "${busID}" ]; then
+		echo "${name}: Error parsing 'pciconf' output"
+		exit 1
+	fi
 }
 
 rc_conf_d_ldconfig()
@@ -141,22 +172,31 @@ ldconfig_paths="\${ldconfig_paths} $1"
 rc_conf_d_END
 }
 
+__wait()
+{
+	n=$1
+	while [ $n -gt 0 ]; do
+		printf "\rWaiting %02d seconds" $n
+		n=$((n - 1))
+		sleep 1
+	done
+	echo
+}
+
 setup_intel()
 {
 	local kmod
 
 	[ "${vendor}" != 8086 ] && return 1
 	if i915_drm_legacy_ids | grep -iq ${device}; then
-		kmod="${path_drm_legacy}/i915kms.ko"
 		xorg_cfg_intel > "${path_xorg_cfg}"
 	else
-		kmod="/boot/modules/i915kms.ko"
 		xorg_cfg_modesetting > "${path_xorg_cfg}"
 	fi
+	kmod="/boot/modules/i915kms.ko"
 	set_kldconfig_path "${kmod}"
 	kldload "${kmod}"
-	set_kldconfig_path "${kmod}"
-	sysrc initgfx_kmods="${kmod}"
+	sysrc -f "${path_tmp_rc_conf}" initgfx_kmods="${kmod}"
 	sync
 	return 0
 }
@@ -174,7 +214,7 @@ setup_ati_amd()
 		kmod="/boot/modules/amdgpu.ko"
 	fi
 	kldload ${kmod}
-	sysrc initgfx_kmods="${kmod}"
+	sysrc -f "${path_tmp_rc_conf}" initgfx_kmods="${kmod}"
 	eval ${driver}_xorg_cfg > "${path_xorg_cfg}"
 	sync
 	return 0
@@ -206,22 +246,38 @@ setup_nvidia()
 	srcdir="${path_nvidia}/${driver}"
 
 	dir=/usr/local/etc/libmap.d 
-	tar -C ${srcdir}${dir} -cf - . | tar -C ${dir} -xkf -
+	tar -C ${srcdir}${dir} -cf - . | tar -C ${dir} -xf -
 
 	rc_conf_d_ldconfig ${srcdir}/usr/local/lib > \
 		/etc/rc.conf.d/ldconfig
 	ldconfig -m /usr/local/nvidia/${driver}/usr/local/lib
 
 	dir=/usr/local/lib/xorg/modules/drivers
-	tar -C "${srcdir}${dir}" -cf - . | tar -C "${dir}" -xkf -
-
+	# Restore symlink if it was removed or overwritten
+	if [ ! -L "${dir}/nvidia_drv.so" ]; then
+		if [ ! -d "/nvidia/${dir}" ]; then
+			mkdir -p "/nvidia/${dir}"
+		fi
+		rm -f "${dir}/nvidia_drv.so"
+		ln -s "/nvidia/${dir}/nvidia_drv.so" "${dir}/"
+	fi
+	tar -C "${srcdir}${dir}" -cf - . | tar -C "/nvidia/${dir}" -xf -
 	dir=/usr/local/lib/xorg/modules/extensions
-	tar -C "${srcdir}${dir}/.nvidia" -cf - . | tar -C ${dir} -xkf -
-	tar -C "${srcdir}${dir}" \
-		--exclude '.nvidia' -cf - . | tar -C "${dir}" -xkf -
 
-	dir=/usr/local/lib/vdpau
-	tar -C "${srcdir}${dir}" -cf - . | tar -C ${dir} -xkf -
+	# Restore symlink if it was removed or overwritten
+	for l in libglx.so libglx.so.1 libglxserver_nvidia.so \
+			 libglxserver_nvidia.so.1; do
+		if [ ! -L "${dir}/$l" ]; then
+			if [ ! -d "/nvidia/${dir}" ]; then
+				mkdir -p "/nvidia/${dir}"
+			fi
+			rm -f "${dir}/$l"
+			ln -s "/nvidia/${dir}/$l" "${dir}/"
+		fi
+	done
+	tar -C "${srcdir}${dir}/.nvidia" -cf - . | tar -C "/nvidia/${dir}" -xf -
+	tar -C "${srcdir}${dir}" \
+		--exclude '.nvidia' -cf - . | tar -C "/nvidia/${dir}" -xf -
 
 	if [ ${driver} -ge 390 ]; then
 		kmods="${srcdir}/boot/modules/nvidia.ko"
@@ -231,17 +287,46 @@ setup_nvidia()
 		kmods="${srcdir}/boot/modules/nvidia.ko"
 	fi
 	kldload ${kmods}
-	sysrc initgfx_kmods="${kmods}"
+	sysrc -f "${path_tmp_rc_conf}" initgfx_kmods="${kmods}"
 	nvidia_xorg_cfg > "${path_xorg_cfg}"
-	sync
 	return 0
+}
+
+is_vm()
+{
+	pciconf -lv | grep -B3 display | grep -E -q -i 'virtualbox|VMware'
+}
+
+get_fallback_driver()
+{
+	if sysctl machdep.bootmethod | grep -q BIOS; then
+		fallback_driver="vesa"
+	else
+		fallback_driver="scfb"
+	fi
+}
+
+write_fallback_cfg()
+{
+	(printf "Section \"Device\"\n"; \
+	 printf "\tIdentifier \"Card0\"\n"; \
+	 printf "\tDriver \"${fallback_driver}\"\n"; \
+	 printf "\tBusID \"PCI:$busID\"\n"; \
+	 printf "EndSection\n") > "${path_xorg_cfg}"
 }
 
 do_initgfx()
 {
-	local driver
-
 	unalias echo
+	if [ "$(kenv -q initgfx.detect.disable)" = "1" ]; then
+		del_stale_files
+		get_device_info
+		if ! is_vm; then
+			get_fallback_driver
+			write_fallback_cfg
+		fi
+		return
+	fi
 	if check_configured; then
 		initgfx_debug "Using previous configuration ..."
 		for m in ${initgfx_kmods}; do
@@ -252,42 +337,38 @@ do_initgfx()
 	fi
 	initgfx_debug "Creating new configuration ..."
 	del_stale_files
+	cp -a /etc/rc.conf "${path_tmp_rc_conf}"
 
-	# In VirtualBox we are done here
-	if (pciconf -lv | grep -B3 display | grep -q -i virtualbox); then
+	# In VirtualBox and VMware we are done here
+	if is_vm; then
 		save_config_id
 		return
 	fi
-	if sysctl machdep.bootmethod | grep -q BIOS; then
-		driver="vesa"
-	else
-		driver="scfb"
-	fi
+	get_fallback_driver
 	initgfx_debug "Auto-detecting graphics driver ..."
 	get_device_info
-	for i in nvidia intel ati_amd; do
+
+	# Prepare for a crash.
+	for i in nvidia ati_amd intel; do
 		if setup_${i}; then
 			initgfx_debug "Testing Xorg configuration ..."
 			if test_x; then
 				# FIXME: Without the delay the result is a
 				# reboot when using a Nvidia GPU.
-				sleep 3
+				__wait 3
 				save_config_id
+				cp -a "${path_tmp_rc_conf}" /etc/rc.conf
 				return
 			else
 				initgfx_warn "Failed to use $i driver. " \
-							 "Using ${driver} instead ..." >&2
+							 "Using ${fallback_driver} instead ..." >&2
 				del_stale_files
 			fi
 			break
 		fi
 	done
-	(printf "Section \"Device\"\n"; \
-	 printf "\tIdentifier \"Card0\"\n"; \
-	 printf "\tDriver \"${driver}\"\n"; \
-	 printf "\tBusID \"PCI:$busID\"\n"; \
-	 printf "EndSection\n") > "${path_xorg_cfg}"
-
+	write_fallback_cfg
+	cp -a "${path_tmp_rc_conf}" /etc/rc.conf
 	sysrc -x initgfx_kmods
 }
 

--- a/overlays/uzip/initgfx/files/etc/rc.d/initgfx
+++ b/overlays/uzip/initgfx/files/etc/rc.d/initgfx
@@ -129,14 +129,10 @@ get_device_info() {
 		sed -E 's#.* chip=0x([0-9a-z]{4})([0-9a-z]{4}).*$#\1:\2#')
 	busID=$(pciconf -lv | grep ^vgapci${unit} | head -1 | \
 		sed -E 's/^vgapci[0-9]@pci[0-9]:([0-9:]+):.*$/\1/')
-	MAJOR=$(uname -r | cut -d "." -f 1)
-	if [ $MAJOR -lt 13 ] ; then
-		vendor=$(echo "${chip}" | cut -d: -f2)
-		device=$(echo "${chip}" | cut -d: -f1)
-	else
-		vendor=$(pciconf -lv | grep ^vgapci${unit} | head -n 1 | grep -oe ' vendor=0x....' | cut -d x -f 2)
-		device=$(pciconf -lv | grep ^vgapci${unit} | head -n 1 | grep -oe ' device=0x....' | cut -d x -f 2)
-	fi
+	#vendor=$(echo "${chip}" | cut -d: -f2)
+	#device=$(echo "${chip}" | cut -d: -f1)
+	vendor=$(pciconf -lv | grep ^vgapci${unit} | head -n 1 | grep -oe ' vendor=0x....' | cut -d x -f 2)
+	device=$(pciconf -lv | grep ^vgapci${unit} | head -n 1 | grep -oe ' device=0x....' | cut -d x -f 2)
 }
 
 rc_conf_d_ldconfig()


### PR DESCRIPTION
Complete the Intel graphics fixes for those that initgfx decides need drm-kmod-legacy.

Nothing needs this, it's deprecated and will be removed when 11.4 is no longer supported.

The 'new' drm-kmod supports all of them properly.