### PR TITLE
Fix a missing PATH entry that broke localize

### DIFF
--- a/overlays/uzip/localize/files/usr/local/etc/rc.d/localize
+++ b/overlays/uzip/localize/files/usr/local/etc/rc.d/localize
@@ -5,6 +5,9 @@
 # BEFORE:  LOGIN
 # KEYWORD: nojail shutdown
 
+PATH=$PATH:/usr/local/sbin
+export PATH
+
 . /etc/rc.subr
 
 name="localize"


### PR DESCRIPTION
And fixing it broke my timezone :~(

There was a strange error on startup coming from the Python subprocess module, and in trying to figure out why localize didn't work, I noticed that /usr/local/sbin was not in the program's path.