### PR TITLE
build.sh: fix incorrect string comparison

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -24,7 +24,7 @@ if [ "${VERSIONSUFFIX}" = "CURRENT" ] ; then
   FTPDIRECTORY="snapshots"
 fi
 # RCs are in the 'releases' ftp directory; hence check if $VERSIONSUFFIX begins with 'RC' https://serverfault.com/a/252406
-if [ "${VERSIONSUFFIX#RC}"x = "${VERSIONSUFFIX}x" ]  ; then
+if [ "${VERSIONSUFFIX#RC}"x != "${VERSIONSUFFIX}x" ]  ; then
   FTPDIRECTORY="releases"
 fi
 


### PR DESCRIPTION
The current comparison is the negation of the desired
behaviour; it currently sets FTPDIRECTORY to "releases"
if VERSIONSUFFIX does NOT begin with "RC". (refer to the
link in the comment)