### PR TITLE
Part 1 of issue 271

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -429,7 +429,7 @@ boot()
     sed -i -e 's|tmpfs_load=".*"|tmpfs_load="NO"|g' "${cdroot}"/boot/loader.conf
     rm -f "${cdroot}"/boot/loader.conf-e
   fi
-  echo 'exec="mode 0"' >> "${cdroot}"/boot/loader.conf
+  echo 'exec="mode 0"' >> "${cdroot}"/boot/loader.conf # Prevent the FreeBSD 13 bootloader from changing the screen resolution, https://github.com/helloSystem/ISO/issues/198#issuecomment-901919172
   sync ### Needed?
 }
 

--- a/build.sh
+++ b/build.sh
@@ -429,6 +429,7 @@ boot()
     sed -i -e 's|tmpfs_load=".*"|tmpfs_load="NO"|g' "${cdroot}"/boot/loader.conf
     rm -f "${cdroot}"/boot/loader.conf-e
   fi
+  echo 'exec="mode 0"' >> "${cdroot}"/boot/loader.conf
   sync ### Needed?
 }
 


### PR DESCRIPTION
FreeBSD 13 bootscreen should go to native resolution and FreeBSD 12 and 13 should got to the monitors native resolution without drivers.