### PR TITLE
Updated README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ root@FreeBSD:/ # curl -L "https://github.com/probonopd/furybsd-livecd/releases/d
 
 ## Credentials for live media
 
-There is no password for `liveuser`. The `liveuser` account is removed upon install.  There is also no root password until it is set in the installer. You can become root using `sudo su`.
+There is no password for `liveuser`. The `liveuser` account is removed upon install.  There is also no root password until it is set in the installer. You can become root using `sudo -i`.
 
 ## Acknowledgements
 


### PR DESCRIPTION
`sudo su` would do two nested processes, one for sudo running su and one for su running the root shell.
Instead, you can use `sudo -i` (where `-i` stands for interactive) and it would pop a root shell directly.