### PR TITLE
Added Settings from CoolTrainer

### DIFF
--- a/overlays/uzip/furybsd-live-settings/files/usr/local/bin/furybsd-install
+++ b/overlays/uzip/furybsd-live-settings/files/usr/local/bin/furybsd-install
@@ -153,6 +153,7 @@ if [ -n "${INSTALLER_DEVICE}" ] ; then
   chroot "${FSMNT}" pw usermod "${username}" -s /usr/local/bin/zsh && \
   chroot "${FSMNT}" pw groupmod wheel -m "${username}" && \
   chroot "${FSMNT}" pw groupmod video -m "${username}" && \
+  chroot "${FSMNT}" pw groupmod operator -m "${username}" && \
   chroot "${FSMNT}" pw groupmod webcamd -m "${username}" && \
   chroot "${FSMNT}" pw groupmod cups -m "${username}"
 else

--- a/overlays/uzip/furybsd-settings/files/etc/sysctl.conf
+++ b/overlays/uzip/furybsd-settings/files/etc/sysctl.conf
@@ -3,6 +3,20 @@
 #  This file is read when going to multi-user and its contents piped thru
 #  ``sysctl'' to adjust kernel values.  ``man 5 sysctl.conf'' for details.
 #
+# https://cooltrainer.org/a-freebsd-desktop-howto/
+# I have been using these settings several years on low spec laptops without any problem.
+# Enhance shared memory X11 interface
+kern.ipc.shmmax=67108864
+kern.ipc.shmall=32768
+
+# Enhance desktop responsiveness under high CPU use (200/224)
+kern.sched.preempt_thresh=224
+
+# Disable PC Speaker
+hw.syscons.bell=0
+
+# Shared memory for Chromium
+kern.ipc.shm_allow_removed=1
 
 # Needed for Baloo local file indexing
 kern.maxfiles=3000000

--- a/overlays/uzip/furybsd-settings/files/etc/sysctl.conf
+++ b/overlays/uzip/furybsd-settings/files/etc/sysctl.conf
@@ -4,7 +4,7 @@
 #  ``sysctl'' to adjust kernel values.  ``man 5 sysctl.conf'' for details.
 #
 # https://cooltrainer.org/a-freebsd-desktop-howto/
-# I have been using these settings several years on low spec laptops without any problem.
+# These settings have been used several years on low spec laptops without any problem.
 # Enhance shared memory X11 interface
 kern.ipc.shmmax=67108864
 kern.ipc.shmall=32768


### PR DESCRIPTION
I have been using these  tunables from https://cooltrainer.org/a-freebsd-desktop-howto/ without any problems in low spec laptops. Would be nice to have it out of the box in hellosystem.
Also according to devfs.rules user should be in the operator group.