### PR TITLE
MacBook Pro booting the ISO with nothing in the SD slot will panic re…

### DIFF
--- a/overlays/boot/boot/loader.conf
+++ b/overlays/boot/boot/loader.conf
@@ -84,3 +84,11 @@ loader_conf_dirs="/boot/loader.mute.d /boot/loader.conf.d"
 
 # Prevent dhclient from locking up, https://github.com/helloSystem/hello/discussions/297
 dev.bge.0.msi=0
+
+# Fix Kernel panic during boot from live media on MacBook when SD slot is empty #505
+hw.usb.quirk.0="0x05ac 0x8406 0 0xffff UQ_MSC_NO_INQUIRY"
+hw.usb.quirk.1="0x05ac 0x8406 0 0xffff UQ_MSC_NO_RS_CLEAR_UA"
+hw.usb.quirk.2="0x05ac 0x8406 0 0xffff UQ_MSC_NO_TEST_UNIT_READY"
+hw.usb.quirk.3="0x05ac 0x8406 0 0xffff UQ_MSC_NO_START_STOP"
+hw.usb.quirk.4="0x05ac 0x8406 0 0xffff UQ_MSC_NO_INQUIRY_EVPD"
+


### PR DESCRIPTION
…boot.

These usb quirks allow the driver to bypass discovery on an empty device. This will only work on SD readers matching the following vendor:product ID.

    Bus 002 Device 003: ID 05ac:8406 Apple, Inc. Internal Memory Card Reader